### PR TITLE
URL-encode CopySource key per AWS documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
       "version": "2.192.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.192.0.tgz",
       "integrity": "sha1-QXDZCGvR8H51F8xHutN9EmduxSo=",
+      "dev": true,
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -292,7 +293,8 @@
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -342,6 +344,7 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dev": true,
       "requires": {
         "base64-js": "1.2.1",
         "ieee754": "1.1.8",
@@ -619,7 +622,8 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
     },
     "extend": {
       "version": "3.0.1",
@@ -793,7 +797,8 @@
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -838,7 +843,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -849,7 +855,8 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -2805,7 +2812,8 @@
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
     },
     "qs": {
       "version": "1.2.2",
@@ -2816,7 +2824,8 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "readable-stream": {
       "version": "1.0.34",
@@ -3083,7 +3092,8 @@
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
     },
     "should": {
       "version": "13.2.1",
@@ -3349,6 +3359,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -3366,7 +3377,8 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -3397,6 +3409,7 @@
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "dev": true,
       "requires": {
         "sax": "1.2.1",
         "xmlbuilder": "4.2.1"
@@ -3406,6 +3419,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+      "dev": true,
       "requires": {
         "lodash": "4.17.5"
       }

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "report-dir": "coverage"
   },
   "dependencies": {
-    "aws-sdk": "^2.192.0",
     "lodash": "^4.17.5"
   },
   "devDependencies": {
+    "aws-sdk": "^2.192.0",
     "bunyan": "^1.8.12",
     "coveralls": "^3.0.0",
     "deepcopy": "^0.6.3",

--- a/src/copy-object-multipart.js
+++ b/src/copy-object-multipart.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const path = require('path');
 
 const DEFAULT_COPY_PART_SIZE_BYTES = 50000000; // 50 MB in bytes
 const DEFAULT_COPIED_OBJECT_PERMISSIONS = 'private';
@@ -70,9 +71,10 @@ function initiateMultipartCopy(destination_bucket, copied_object_name, copied_ob
 };
 
 function copyPart(source_bucket, destination_bucket, part_number, object_key, partition_range, copied_object_name, upload_id) {
+    const encodedSourceKey = encodeURIComponent(path.join(source_bucket, object_key))
     const params = {
         Bucket: destination_bucket,
-        CopySource: source_bucket + '/' + object_key,
+        CopySource: encodedSourceKey,
         CopySourceRange: 'bytes=' + partition_range,
         Key: copied_object_name,
         PartNumber: part_number,

--- a/src/copy-object-multipart.js
+++ b/src/copy-object-multipart.js
@@ -1,14 +1,13 @@
 'use strict';
 
-let AWS = require('aws-sdk'),
-    _ = require('lodash');
+const _ = require('lodash');
 
 const DEFAULT_COPY_PART_SIZE_BYTES = 50000000; // 50 MB in bytes
 const DEFAULT_COPIED_OBJECT_PERMISSIONS = 'private';
 
 let s3, logger;
 
-let init = function (aws_s3_object, initialized_logger) {
+const init = function (aws_s3_object, initialized_logger) {
     s3 = aws_s3_object;
     logger = initialized_logger;
 
@@ -30,10 +29,10 @@ let init = function (aws_s3_object, initialized_logger) {
  * (note that copy_part_size_bytes, copied_object_permissions, expiration_period are optional and will be assigned with default values if not given)
  * @param {*} request_context optional parameter for logging purposes
  */
-let copyObjectMultipart = async function ({ source_bucket, object_key, destination_bucket, copied_object_name, object_size, copy_part_size_bytes, copied_object_permissions, expiration_period }, request_context) {
-    let upload_id = await initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context);
-    let partitionsRangeArray = calculatePartitionsRangeArray(object_size, copy_part_size_bytes);
-    let copyPartFunctionsArray = [];
+const copyObjectMultipart = async function ({ source_bucket, object_key, destination_bucket, copied_object_name, object_size, copy_part_size_bytes, copied_object_permissions, expiration_period }, request_context) {
+    const upload_id = await initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context);
+    const partitionsRangeArray = calculatePartitionsRangeArray(object_size, copy_part_size_bytes);
+    const copyPartFunctionsArray = [];
 
     partitionsRangeArray.forEach((partitionRange, index) => {
         copyPartFunctionsArray.push(copyPart(source_bucket, destination_bucket, index + 1, object_key, partitionRange, copied_object_name, upload_id));
@@ -43,16 +42,16 @@ let copyObjectMultipart = async function ({ source_bucket, object_key, destinati
         .then((copy_results) => {
             logger.info({ msg: 'copied all parts successfully: ' + copy_results.toString(), context: request_context })
 
-            let copyResultsForCopyCompletion = prepareResultsForCopyCompletion(copy_results);
+            const copyResultsForCopyCompletion = prepareResultsForCopyCompletion(copy_results);
             return completeMultipartCopy(destination_bucket, copyResultsForCopyCompletion, copied_object_name, upload_id, request_context);
         })
-        .catch((err) => {
+        .catch(() => {
             return abortMultipartCopy(destination_bucket, copied_object_name, upload_id, request_context);
         });
 };
 
 function initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context) {
-    let params = {
+    const params = {
         Bucket: destination_bucket,
         Key: copied_object_name,
         ACL: copied_object_permissions || DEFAULT_COPIED_OBJECT_PERMISSIONS
@@ -71,7 +70,7 @@ function initiateMultipartCopy(destination_bucket, copied_object_name, copied_ob
 };
 
 function copyPart(source_bucket, destination_bucket, part_number, object_key, partition_range, copied_object_name, upload_id) {
-    let params = {
+    const params = {
         Bucket: destination_bucket,
         CopySource: source_bucket + '/' + object_key,
         CopySourceRange: 'bytes=' + partition_range,
@@ -92,14 +91,14 @@ function copyPart(source_bucket, destination_bucket, part_number, object_key, pa
 }
 
 function abortMultipartCopy(destination_bucket, copied_object_name, upload_id, request_context) {
-    let params = {
+    const params = {
         Bucket: destination_bucket,
         Key: copied_object_name,
         UploadId: upload_id
     };
 
     return s3.abortMultipartUpload(params).promise()
-        .then((result) => {
+        .then(() => {
             return s3.listParts(params).promise()
         })
         .catch((err) => {
@@ -111,14 +110,14 @@ function abortMultipartCopy(destination_bucket, copied_object_name, upload_id, r
             if (parts_list.Parts.length > 0) {
                 logger.error({ msg: 'abort multipart copy failed, copy parts were not removed', context: request_context, parts_list: parts_list });
 
-                let err = new Error('Abort procedure passed but copy parts were not removed')
+                const err = new Error('Abort procedure passed but copy parts were not removed')
                 err.details = parts_list;
 
                 return Promise.reject(err);
             } else {
                 logger.info({ msg: 'multipart copy aborted successfully: ' + JSON.stringify(parts_list), context: request_context });
 
-                let err = new Error('multipart copy aborted');
+                const err = new Error('multipart copy aborted');
                 err.details = params;
 
                 return Promise.reject(err);
@@ -127,7 +126,7 @@ function abortMultipartCopy(destination_bucket, copied_object_name, upload_id, r
 };
 
 function completeMultipartCopy(destination_bucket, ETags_array, copied_object_name, upload_id, request_context) {
-    let params = {
+    const params = {
         Bucket: destination_bucket,
         Key: copied_object_name,
         MultipartUpload: {
@@ -148,10 +147,10 @@ function completeMultipartCopy(destination_bucket, ETags_array, copied_object_na
 }
 
 function calculatePartitionsRangeArray(object_size, copy_part_size_bytes) {
-    let partitions = [];
-    let copy_part_size = copy_part_size_bytes || DEFAULT_COPY_PART_SIZE_BYTES;
-    let numOfPartitions = Math.floor(object_size / copy_part_size);
-    let remainder = object_size % copy_part_size;
+    const partitions = [];
+    const copy_part_size = copy_part_size_bytes || DEFAULT_COPY_PART_SIZE_BYTES;
+    const numOfPartitions = Math.floor(object_size / copy_part_size);
+    const remainder = object_size % copy_part_size;
     let index, partition;
 
     for (index = 0; index < numOfPartitions; index++) {
@@ -168,10 +167,10 @@ function calculatePartitionsRangeArray(object_size, copy_part_size_bytes) {
 };
 
 function prepareResultsForCopyCompletion(copy_parts_results_array) {
-    let resultArray = [];
+    const resultArray = [];
 
     copy_parts_results_array.forEach((copy_part, index) => {
-        let newCopyPart = {};
+        const newCopyPart = {};
         newCopyPart.ETag = copy_part.CopyPartResult.ETag;
         newCopyPart.PartNumber = index + 1;
         resultArray.push(newCopyPart);

--- a/test/unit-tests/copy-object-multipart-test.js
+++ b/test/unit-tests/copy-object-multipart-test.js
@@ -154,6 +154,26 @@ describe('AWS S3 multupart copy client unit tests', function () {
                 })
         });
 
+        it('Should url-encode CopySource key', function () {
+            createMultipartUploadStub.returns(testData.createMultipartUploadStub_positive_response);
+            uploadPartCopyStub.returns(testData.uploadPartCopyStub_positive_response);
+            completeMultipartUploadStub.returns(testData.completeMultipartUploadStub_positive_response);
+
+            const partial_request_options = deepCopy(testData.partial_request_options);
+            partial_request_options.object_key = '+?=/&_-.txt';
+            const expected_uploadPartCopy_firstCallArgs = deepCopy(testData.expected_uploadPartCopy_firstCallArgs);
+            expected_uploadPartCopy_firstCallArgs.CopySource = 'source_bucket%2F%2B%3F%3D%2F%26_-.txt';
+            const expected_uploadPartCopy_secondCallArgs = deepCopy(testData.expected_uploadPartCopy_secondCallArgs);
+            expected_uploadPartCopy_secondCallArgs.CopySource = 'source_bucket%2F%2B%3F%3D%2F%26_-.txt';
+            expected_uploadPartCopy_secondCallArgs.CopySourceRange = 'bytes=50000000-99999999';
+
+            return s3Module.copyObjectMultipart(partial_request_options, testData.request_context)
+                .then(() => {
+                    should(uploadPartCopyStub.args[0][0]).eql(expected_uploadPartCopy_firstCallArgs);
+                    should(uploadPartCopyStub.args[1][0]).eql(expected_uploadPartCopy_secondCallArgs);
+                })
+        });
+
         it('Should succeed with all variables passed and object_size is smaller then copy_part_size_bytes', function () {
             createMultipartUploadStub.returns(testData.createMultipartUploadStub_positive_response);
             uploadPartCopyStub.returns(testData.uploadPartCopyStub_positive_response);

--- a/test/utils/unit-tests-data.js
+++ b/test/utils/unit-tests-data.js
@@ -35,7 +35,7 @@ module.exports = {
     },
     expected_uploadPartCopy_firstCallArgs: {
         Bucket: 'destination_bucket',
-        CopySource: 'source_bucket/object_key',
+        CopySource: 'source_bucket%2Fobject_key',
         CopySourceRange: 'bytes=0-49999999',
         Key: 'copied_object_name',
         PartNumber: 1,
@@ -43,7 +43,7 @@ module.exports = {
     },
     expected_uploadPartCopy_secondCallArgs: {
         Bucket: 'destination_bucket',
-        CopySource: 'source_bucket/object_key',
+        CopySource: 'source_bucket%2Fobject_key',
         CopySourceRange: 'bytes=50000000-69999999',
         Key: 'copied_object_name',
         PartNumber: 2,


### PR DESCRIPTION
We had a bug for multipart copy with special characters.
After looking through AWS documentation, I've seen this:

> CopySource — (String) The name of the source bucket and key name of the source object, separated by a slash (/). **Must be URL-encoded**.

Hence this PR where I encode the CopySource URL.
And a few BSR.

https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#uploadPartCopy-property