### PR TITLE
Allow sending S3 object metadata & cache control

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ The method receives two parameters: options and request_context
         ** if object size does not divide exactly with the part size desired, last part will be smaller or larger (depending on remainder size)
     - copied_object_permissions: String (optional) - The permissions to be given for the copied object as specified in [aws s3 ACL docs](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#permissions), if not passed it will be set to a default of 'private'
     - expiration_period: Integer/Date (optional) - A number (milliseconds) or Date indicating the time the copied object will remain in the destination before it will be deleted, if not passed there will be no expiration period for the object
+    - content_type: String (optional) A standard MIME type describing the format of the object data
 - request_context: String (optional) - this parameter will be logged in every log message, if not passed it will remain undefined.
 
 ### Response

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@ The method receives two parameters: options and request_context
     - copied_object_permissions: String (optional) - The permissions to be given for the copied object as specified in [aws s3 ACL docs](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#permissions), if not passed it will be set to a default of 'private'
     - expiration_period: Integer/Date (optional) - A number (milliseconds) or Date indicating the time the copied object will remain in the destination before it will be deleted, if not passed there will be no expiration period for the object
     - content_type: String (optional) A standard MIME type describing the format of the object data
+    - metadata: Object (optional) - A map of metadata to store with the object in S3
 - request_context: String (optional) - this parameter will be logged in every log message, if not passed it will remain undefined.
 
 ### Response

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ The method receives two parameters: options and request_context
     - expiration_period: Integer/Date (optional) - A number (milliseconds) or Date indicating the time the copied object will remain in the destination before it will be deleted, if not passed there will be no expiration period for the object
     - content_type: String (optional) A standard MIME type describing the format of the object data
     - metadata: Object (optional) - A map of metadata to store with the object in S3
+    - cache_control: String (optional) - Specifies caching behavior along the request/reply chain
 - request_context: String (optional) - this parameter will be logged in every log message, if not passed it will remain undefined.
 
 ### Response

--- a/src/copy-object-multipart.js
+++ b/src/copy-object-multipart.js
@@ -30,8 +30,8 @@ const init = function (aws_s3_object, initialized_logger) {
  * (note that copy_part_size_bytes, copied_object_permissions, expiration_period are optional and will be assigned with default values if not given)
  * @param {*} request_context optional parameter for logging purposes
  */
-const copyObjectMultipart = async function ({ source_bucket, object_key, destination_bucket, copied_object_name, object_size, copy_part_size_bytes, copied_object_permissions, expiration_period, server_side_encryption, content_type }, request_context) {
-    const upload_id = await initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type);
+const copyObjectMultipart = async function ({ source_bucket, object_key, destination_bucket, copied_object_name, object_size, copy_part_size_bytes, copied_object_permissions, expiration_period, server_side_encryption, content_type, metadata }, request_context) {
+    const upload_id = await initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, metadata);
     const partitionsRangeArray = calculatePartitionsRangeArray(object_size, copy_part_size_bytes);
     const copyPartFunctionsArray = [];
 
@@ -51,7 +51,7 @@ const copyObjectMultipart = async function ({ source_bucket, object_key, destina
         });
 };
 
-function initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type) {
+function initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, metadata) {
     const params = {
         Bucket: destination_bucket,
         Key: copied_object_name,
@@ -59,6 +59,7 @@ function initiateMultipartCopy(destination_bucket, copied_object_name, copied_ob
     };
     expiration_period ? params.Expires = expiration_period : null;
     content_type ? params.ContentType = content_type : null;
+    metadata ? params.Metadata = metadata : null;
     server_side_encryption ? params.ServerSideEncryption = server_side_encryption : null;
 
     return s3.createMultipartUpload(params).promise()

--- a/src/copy-object-multipart.js
+++ b/src/copy-object-multipart.js
@@ -30,8 +30,8 @@ const init = function (aws_s3_object, initialized_logger) {
  * (note that copy_part_size_bytes, copied_object_permissions, expiration_period are optional and will be assigned with default values if not given)
  * @param {*} request_context optional parameter for logging purposes
  */
-const copyObjectMultipart = async function ({ source_bucket, object_key, destination_bucket, copied_object_name, object_size, copy_part_size_bytes, copied_object_permissions, expiration_period, server_side_encryption, content_type, metadata }, request_context) {
-    const upload_id = await initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, metadata);
+const copyObjectMultipart = async function ({ source_bucket, object_key, destination_bucket, copied_object_name, object_size, copy_part_size_bytes, copied_object_permissions, expiration_period, server_side_encryption, content_type, metadata, cache_control }, request_context) {
+    const upload_id = await initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, metadata, cache_control);
     const partitionsRangeArray = calculatePartitionsRangeArray(object_size, copy_part_size_bytes);
     const copyPartFunctionsArray = [];
 
@@ -51,7 +51,7 @@ const copyObjectMultipart = async function ({ source_bucket, object_key, destina
         });
 };
 
-function initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, metadata) {
+function initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, metadata, cache_control) {
     const params = {
         Bucket: destination_bucket,
         Key: copied_object_name,
@@ -60,6 +60,7 @@ function initiateMultipartCopy(destination_bucket, copied_object_name, copied_ob
     expiration_period ? params.Expires = expiration_period : null;
     content_type ? params.ContentType = content_type : null;
     metadata ? params.Metadata = metadata : null;
+    cache_control ? params.CacheControl = cache_control : null;
     server_side_encryption ? params.ServerSideEncryption = server_side_encryption : null;
 
     return s3.createMultipartUpload(params).promise()

--- a/test/utils/unit-tests-data.js
+++ b/test/utils/unit-tests-data.js
@@ -20,7 +20,9 @@ module.exports = {
         copied_object_permissions: 'copied_object_permissions',
         expiration_period: 100000,
         server_side_encryption: 'AES256',
-        content_type: 'application/json'
+        content_type: 'application/json',
+        metadata: { 'some-key': 'some-value' },
+        cache_control: 'max-age=60'
     },
     partial_request_options: { // no copy_part_size_bytes, no copied_object_permissions, no expiration_period,  no server_side_encryption, no content_type
         source_bucket: 'source_bucket',

--- a/test/utils/unit-tests-data.js
+++ b/test/utils/unit-tests-data.js
@@ -37,7 +37,11 @@ module.exports = {
         ACL: 'copied_object_permissions',
         Expires: 100000,
         ServerSideEncryption: 'AES256',
-        ContentType: 'application/json'
+        ContentType: 'application/json',
+        CacheControl: 'max-age=60',
+        Metadata: {
+            'some-key': 'some-value'
+        }
     },
     expected_uploadPartCopy_firstCallArgs: {
         Bucket: 'destination_bucket',


### PR DESCRIPTION
Adds optional `metadata` & `cache_control` parameters.

Thanks for this great package!