### PR TITLE
Add optional sse_mks_key_id parameter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ The method receives two parameters: options and request_context
     - content_type: String (optional) A standard MIME type describing the format of the object data
     - metadata: Object (optional) - A map of metadata to store with the object in S3
     - cache_control: String (optional) - Specifies caching behavior along the request/reply chain
+    - sse_mks_key_id: String(optional) - Specifies the ARN of the KMS key to be used for file encryption (server_side_encryption must be "aws:kms")
 - request_context: String (optional) - this parameter will be logged in every log message, if not passed it will remain undefined.
 
 ### Response

--- a/src/copy-object-multipart.js
+++ b/src/copy-object-multipart.js
@@ -29,8 +29,8 @@ const init = function (aws_s3_object, initialized_logger) {
  * (note that copy_part_size_bytes, copied_object_permissions, expiration_period are optional and will be assigned with default values if not given)
  * @param {*} request_context optional parameter for logging purposes
  */
-const copyObjectMultipart = async function ({ source_bucket, object_key, destination_bucket, copied_object_name, object_size, copy_part_size_bytes, copied_object_permissions, expiration_period, server_side_encryption, content_type, content_disposition, content_encoding, content_language, metadata, cache_control }, request_context) {
-    const upload_id = await initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, content_disposition,  content_encoding, content_language, metadata, cache_control);
+const copyObjectMultipart = async function ({ source_bucket, object_key, destination_bucket, copied_object_name, object_size, copy_part_size_bytes, copied_object_permissions, expiration_period, server_side_encryption, content_type, content_disposition, content_encoding, content_language, metadata, cache_control, sse_mks_key_id }, request_context) {
+    const upload_id = await initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, content_disposition,  content_encoding, content_language, metadata, cache_control, sse_mks_key_id);
     const partitionsRangeArray = calculatePartitionsRangeArray(object_size, copy_part_size_bytes);
     const copyPartFunctionsArray = [];
 
@@ -50,7 +50,7 @@ const copyObjectMultipart = async function ({ source_bucket, object_key, destina
         });
 };
 
-function initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, content_disposition, content_encoding, content_language, metadata, cache_control) {
+function initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, content_disposition, content_encoding, content_language, metadata, cache_control, sse_mks_key_id) {
     const params = {
         Bucket: destination_bucket,
         Key: copied_object_name,
@@ -64,6 +64,7 @@ function initiateMultipartCopy(destination_bucket, copied_object_name, copied_ob
     metadata ? params.Metadata = metadata : null;
     cache_control ? params.CacheControl = cache_control : null;
     server_side_encryption ? params.ServerSideEncryption = server_side_encryption : null;
+    sse_mks_key_id ? params.SSEKMSKeyId = sse_mks_key_id : null;
 
     return s3.createMultipartUpload(params).promise()
         .then((result) => {

--- a/test/unit-tests/copy-object-multipart-test.js
+++ b/test/unit-tests/copy-object-multipart-test.js
@@ -20,7 +20,7 @@ let bunyan = require('bunyan'),
 
 let sandBox, loggerInfoSpy, loggerErrorSpy, createMultipartUploadStub, uploadPartCopyStub, completeMultipartUploadStub, abortMultipartUploadStub, listPartsStub, s3;
 
-describe('AWS S3 multupart copy client unit tests', function () {
+describe('AWS S3 multipart copy client unit tests', function () {
     before(() => {
         sandBox = sinon.sandbox.create();
         loggerInfoSpy = sandBox.spy(logger, 'info');

--- a/test/utils/unit-tests-data.js
+++ b/test/utils/unit-tests-data.js
@@ -25,9 +25,10 @@ module.exports = {
         content_encoding: 'gzip',
         content_language: 'en-US',
         metadata: { 'some-key': 'some-value' },
-        cache_control: 'max-age=60'
+        cache_control: 'max-age=60',
+        sse_mks_key_id: "sse-key-arn"
     },
-    partial_request_options: { // no copy_part_size_bytes, no copied_object_permissions, no expiration_period,  no server_side_encryption, no content_type
+    partial_request_options: { // no copy_part_size_bytes, no copied_object_permissions, no expiration_period,  no server_side_encryption, no content_type, no sse_mks_key_id
         source_bucket: 'source_bucket',
         object_key: 'object_key',
         destination_bucket: 'destination_bucket',
@@ -47,7 +48,8 @@ module.exports = {
         CacheControl: 'max-age=60',
         Metadata: {
             'some-key': 'some-value'
-        }
+        },
+        SSEKMSKeyId: "sse-key-arn"
     },
     expected_uploadPartCopy_firstCallArgs: {
         Bucket: 'destination_bucket',

--- a/test/utils/unit-tests-data.js
+++ b/test/utils/unit-tests-data.js
@@ -26,7 +26,7 @@ module.exports = {
         content_language: 'en-US',
         metadata: { 'some-key': 'some-value' },
         cache_control: 'max-age=60',
-        sse_mks_key_id: "sse-key-arn"
+        sse_mks_key_id: 'sse-key-arn'
     },
     partial_request_options: { // no copy_part_size_bytes, no copied_object_permissions, no expiration_period,  no server_side_encryption, no content_type, no sse_mks_key_id
         source_bucket: 'source_bucket',
@@ -49,7 +49,7 @@ module.exports = {
         Metadata: {
             'some-key': 'some-value'
         },
-        SSEKMSKeyId: "sse-key-arn"
+        SSEKMSKeyId: 'sse-key-arn'
     },
     expected_uploadPartCopy_firstCallArgs: {
         Bucket: 'destination_bucket',


### PR DESCRIPTION
Add an optional `sse_mks_key_id` parameter to specify the ID of the symmetric customer-managed key to use for object encryption.

This will add the _x-amz-server-side-encryption-aws-kms-key-id_ param in the request for the CreateMultiPartUpload operation (see [AWS API docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html#API_CreateMultipartUpload_ResponseSyntax) for reference).