### PR TITLE
Add support for the storage_class option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,10 +25,14 @@ npm install aws-s3-multipart-copy
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!--**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*-->
 
-- [init](#init)
-- [copyObjectMultipart](#copyobjectmultipart)
+- [aws-s3-multipart-copy](#aws-s3-multipart-copy)
+  - [Installing](#installing)
+  - [init](#init)
+    - [Example](#example)
+  - [copyObjectMultipart](#copyobjectmultipart)
     - [Request parameters](#request-parameters)
     - [Response](#response)
+    - [Example](#example-1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -80,6 +84,7 @@ The method receives two parameters: options and request_context
     - content_type: String (optional) A standard MIME type describing the format of the object data
     - metadata: Object (optional) - A map of metadata to store with the object in S3
     - cache_control: String (optional) - Specifies caching behavior along the request/reply chain
+    - storage_class: String (optional) - Specifies the storage class for the copied object. The valid values are specified in the [aws s3 docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html#AmazonS3-CreateMultipartUpload-request-header-StorageClass). When unset, the class will be 'STANDARD'
 - request_context: String (optional) - this parameter will be logged in every log message, if not passed it will remain undefined.
 
 ### Response
@@ -116,7 +121,8 @@ let options = {
         object_size: 70000000,
         copy_part_size_bytes: 50000000,
         copied_object_permissions: 'bucket-owner-full-control',
-        expiration_period: 100000
+        expiration_period: 100000,
+        storage_class: 'STANDARD'
     };
 
     return s3Module.copyObjectMultipart(options, request_context)
@@ -149,7 +155,8 @@ let options = {
         object_size: 70000000,
         copy_part_size_bytes: 50000000,
         copied_object_permissions: 'bucket-owner-full-control',
-        expiration_period: 100000
+        expiration_period: 100000,
+        storage_class: 'STANDARD'
     };
 
     return s3Module.copyObjectMultipart(options, request_context)
@@ -180,7 +187,8 @@ let options = {
         object_size: 70000000,
         copy_part_size_bytes: 50000000,
         copied_object_permissions: 'bucket-owner-full-control',
-        expiration_period: 100000
+        expiration_period: 100000,
+        storage_class: 'STANDARD'
     };
 
     return s3Module.copyObjectMultipart(options, request_context)

--- a/src/copy-object-multipart.js
+++ b/src/copy-object-multipart.js
@@ -29,8 +29,8 @@ const init = function (aws_s3_object, initialized_logger) {
  * (note that copy_part_size_bytes, copied_object_permissions, expiration_period are optional and will be assigned with default values if not given)
  * @param {*} request_context optional parameter for logging purposes
  */
-const copyObjectMultipart = async function ({ source_bucket, object_key, destination_bucket, copied_object_name, object_size, copy_part_size_bytes, copied_object_permissions, expiration_period, server_side_encryption, content_type, content_disposition, content_encoding, content_language, metadata, cache_control }, request_context) {
-    const upload_id = await initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, content_disposition,  content_encoding, content_language, metadata, cache_control);
+const copyObjectMultipart = async function ({ source_bucket, object_key, destination_bucket, copied_object_name, object_size, copy_part_size_bytes, copied_object_permissions, expiration_period, server_side_encryption, content_type, content_disposition, content_encoding, content_language, metadata, cache_control, storage_class}, request_context) {
+    const upload_id = await initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, content_disposition,  content_encoding, content_language, metadata, cache_control, storage_class);
     const partitionsRangeArray = calculatePartitionsRangeArray(object_size, copy_part_size_bytes);
     const copyPartFunctionsArray = [];
 
@@ -50,7 +50,7 @@ const copyObjectMultipart = async function ({ source_bucket, object_key, destina
         });
 };
 
-function initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, content_disposition, content_encoding, content_language, metadata, cache_control) {
+function initiateMultipartCopy(destination_bucket, copied_object_name, copied_object_permissions, expiration_period, request_context, server_side_encryption, content_type, content_disposition, content_encoding, content_language, metadata, cache_control, storage_class) {
     const params = {
         Bucket: destination_bucket,
         Key: copied_object_name,
@@ -64,6 +64,7 @@ function initiateMultipartCopy(destination_bucket, copied_object_name, copied_ob
     metadata ? params.Metadata = metadata : null;
     cache_control ? params.CacheControl = cache_control : null;
     server_side_encryption ? params.ServerSideEncryption = server_side_encryption : null;
+    storage_class ? params.StorageClass = storage_class : null;
 
     return s3.createMultipartUpload(params).promise()
         .then((result) => {

--- a/test/utils/unit-tests-data.js
+++ b/test/utils/unit-tests-data.js
@@ -25,7 +25,8 @@ module.exports = {
         content_encoding: 'gzip',
         content_language: 'en-US',
         metadata: { 'some-key': 'some-value' },
-        cache_control: 'max-age=60'
+        cache_control: 'max-age=60',
+        storage_class: 'STANDARD'
     },
     partial_request_options: { // no copy_part_size_bytes, no copied_object_permissions, no expiration_period,  no server_side_encryption, no content_type
         source_bucket: 'source_bucket',
@@ -47,7 +48,8 @@ module.exports = {
         CacheControl: 'max-age=60',
         Metadata: {
             'some-key': 'some-value'
-        }
+        },
+        StorageClass: 'STANDARD'
     },
     expected_uploadPartCopy_firstCallArgs: {
         Bucket: 'destination_bucket',


### PR DESCRIPTION
This simple change adds support for a `storage_class` option. This allows setting the destination object's storage class, using one of the classes defined [here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html#AmazonS3-CreateMultipartUpload-request-header-StorageClass).

Note that bucket to bucket copy is the required procedure to change an object's storage class ([source](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html#sc-howtoset)). Having the ability to do this with a multipart copy can help to drastically speed up this operation.